### PR TITLE
Fix to compile helloworld example on LLVM 12

### DIFF
--- a/Il2Native.Logic/Gencode/ArraySingleDimensionGen.cs
+++ b/Il2Native.Logic/Gencode/ArraySingleDimensionGen.cs
@@ -293,6 +293,8 @@ namespace Il2Native.Logic.Gencode
             // save element size
             llvmWriter.WriteSetResultNumber(opCode, intType);
             writer.Write("getelementptr inbounds ");
+            arrayInstanceResult.Type.WriteTypePrefix2(writer);
+            writer.Write(", ");
             arrayInstanceResult.Type.WriteTypePrefix(writer);
             writer.Write(" ");
             llvmWriter.WriteResult(arrayInstanceResult);
@@ -310,6 +312,8 @@ namespace Il2Native.Logic.Gencode
             // save array size
             llvmWriter.WriteSetResultNumber(opCode, intType);
             writer.Write("getelementptr inbounds ");
+            arrayInstanceResult.Type.WriteTypePrefix2(writer);
+            writer.Write(", ");
             arrayInstanceResult.Type.WriteTypePrefix(writer);
             writer.Write(" ");
             llvmWriter.WriteResult(arrayInstanceResult);
@@ -362,6 +366,8 @@ namespace Il2Native.Logic.Gencode
 
             var result = llvmWriter.WriteSetResultNumber(opCode, dataType);
             writer.Write("getelementptr ");
+            arrayInstanceResult.Type.WriteTypePrefix2(writer, true);
+            writer.Write(", ");
             arrayInstanceResult.Type.WriteTypePrefix(writer, true);
 
             writer.Write(" ");

--- a/Il2Native.Logic/Gencode/CallGen.cs
+++ b/Il2Native.Logic/Gencode/CallGen.cs
@@ -211,7 +211,9 @@ namespace Il2Native.Logic.Gencode
             parameter.ParameterType.WriteTypePrefix(writer, parameter.ParameterType.IsStructureType());
             if (parameter.ParameterType.IsStructureType() && !parameter.IsOut && !parameter.IsRef)
             {
-                writer.Write(" byval align " + LlvmWriter.PointerSize);
+                writer.Write(" byval(");
+                parameter.ParameterType.WriteTypePrefix2(writer, parameter.ParameterType.IsStructureType());
+                writer.Write(") align " + LlvmWriter.PointerSize);
             }
 
             writer.Write(' ');
@@ -227,7 +229,9 @@ namespace Il2Native.Logic.Gencode
             type.WriteTypePrefix(writer, type.IsStructureType());
             if (type.IsStructureType())
             {
-                writer.Write(" byval align " + LlvmWriter.PointerSize);
+                writer.Write(" byval(");
+                type.WriteTypePrefix2(writer, type.IsStructureType());
+                writer.Write(") align " + LlvmWriter.PointerSize);
             }
 
             writer.Write(' ');

--- a/Il2Native.Logic/Gencode/ExceptionHandlingGen.cs
+++ b/Il2Native.Logic/Gencode/ExceptionHandlingGen.cs
@@ -100,7 +100,7 @@ namespace Il2Native.Logic.Gencode
             var opCodeNone = OpCodePart.CreateNop;
             var bytePointerType = llvmWriter.ResolveType("System.Byte").ToPointerType();
             var errorObjectOfCatchResultNumber = llvmWriter.WriteSetResultNumber(opCodeNone, bytePointerType);
-            writer.WriteLine("load i8** %.error_object");
+            writer.WriteLine("load i8*, i8** %.error_object");
             var beginCatchResultNumber = llvmWriter.WriteSetResultNumber(opCodeNone, bytePointerType);
             writer.WriteLine("call i8* @__cxa_begin_catch(i8* {0})", errorObjectOfCatchResultNumber);
             if (catchType != null)
@@ -317,7 +317,7 @@ namespace Il2Native.Logic.Gencode
 
             var opCodeNone = OpCodePart.CreateNop;
             var errorTypeIdOfCatchResultNumber = llvmWriter.WriteSetResultNumber(opCodeNone, llvmWriter.ResolveType("System.Int32"));
-            writer.WriteLine("load i32* %.error_typeid");
+            writer.WriteLine("load i32, i32* %.error_typeid");
             var errorTypeIdOfExceptionResultNumber = llvmWriter.WriteSetResultNumber(opCodeNone, llvmWriter.ResolveType("System.Byte").ToPointerType());
             writer.Write("call i32 @llvm.eh.typeid.for(i8* bitcast (");
             catchType.WriteRttiPointerClassInfoDeclaration(writer);
@@ -415,7 +415,7 @@ namespace Il2Native.Logic.Gencode
 
             var landingPadResult = llvmWriter.WriteSetResultNumber(opCode, llvmWriter.ResolveType("System.Byte").ToPointerType());
 
-            writer.WriteLine("landingpad { i8*, i32 } personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*)");
+            writer.WriteLine("landingpad { i8*, i32 }");
             if (options.HasFlag(LandingPadOptions.Cleanup))
             {
                 writer.Indent++;
@@ -519,9 +519,9 @@ namespace Il2Native.Logic.Gencode
 
             var opCodeNone = OpCodePart.CreateNop;
             var getErrorObjectResultNumber = llvmWriter.WriteSetResultNumber(opCodeNone, llvmWriter.ResolveType("System.Byte").ToPointerType());
-            writer.WriteLine("load i8** %.error_object");
+            writer.WriteLine("load i8*, i8** %.error_object");
             var getErrorTypeIdResultNumber = llvmWriter.WriteSetResultNumber(opCodeNone, llvmWriter.ResolveType("System.Int32"));
-            writer.WriteLine("load i32* %.error_typeid");
+            writer.WriteLine("load i32, i32* %.error_typeid");
             var insertedErrorObjectResultNumber = llvmWriter.WriteSetResultNumber(opCodeNone, llvmWriter.ResolveType("System.Byte").ToPointerType());
             writer.WriteLine("insertvalue {1} undef, i8* {0}, 0", getErrorObjectResultNumber, "{ i8*, i32 }");
             var insertedErrorTypeIdResultNumber = llvmWriter.WriteSetResultNumber(opCodeNone, llvmWriter.ResolveType("System.Byte").ToPointerType());
@@ -582,7 +582,7 @@ namespace Il2Native.Logic.Gencode
             writer.WriteLine(".unexpected:");
             writer.Indent++;
             var result = llvmWriter.WriteSetResultNumber(null, llvmWriter.ResolveType("System.Byte").ToPointerType());
-            writer.WriteLine("load i8** %.error_object");
+            writer.WriteLine("load i8, i8** %.error_object");
             writer.WriteLine("call void @__cxa_call_unexpected(i8* {0})", result);
             writer.WriteLine("unreachable");
         }

--- a/Il2Native.Logic/Gencode/LlvmHelpersGen.cs
+++ b/Il2Native.Logic/Gencode/LlvmHelpersGen.cs
@@ -88,6 +88,8 @@ namespace Il2Native.Logic.Gencode
             llvmWriter.WriteSetResultNumber(opCodeMethodInfo, llvmWriter.ResolveType("System.Byte").ToPointerType().ToPointerType());
             writer.Write("load ");
             llvmWriter.WriteMethodPointerType(writer, methodInfo, thisType);
+            writer.Write("*, ");
+            llvmWriter.WriteMethodPointerType(writer, methodInfo, thisType);
             writer.Write("** ");
             llvmWriter.WriteResult(pointerToInterfaceVirtualTablePointersResultNumber);
             writer.Write(", align {0}", LlvmWriter.PointerSize);
@@ -99,6 +101,8 @@ namespace Il2Native.Logic.Gencode
             llvmWriter.WriteSetResultNumber(opCodeMethodInfo, llvmWriter.ResolveType("System.Byte").ToPointerType());
             writer.Write("getelementptr inbounds ");
             llvmWriter.WriteMethodPointerType(writer, methodInfo, thisType);
+            writer.Write(", ");
+            llvmWriter.WriteMethodPointerType(writer, methodInfo, thisType);
             writer.Write("* ");
             llvmWriter.WriteResult(virtualTableOfMethodPointersResultNumber);
             writer.WriteLine(", i64 {0}", methodIndex);
@@ -107,6 +111,8 @@ namespace Il2Native.Logic.Gencode
             // load method address
             llvmWriter.WriteSetResultNumber(opCodeMethodInfo, llvmWriter.ResolveType("System.Byte").ToPointerType());
             writer.Write("load ");
+            llvmWriter.WriteMethodPointerType(writer, methodInfo, thisType);
+            writer.Write(", ");
             llvmWriter.WriteMethodPointerType(writer, methodInfo, thisType);
             writer.Write("* ");
             llvmWriter.WriteResult(pointerToFunctionPointerResultNumber);
@@ -532,7 +538,7 @@ namespace Il2Native.Logic.Gencode
                 // extra support
                 if (methodInfo.IsExternalLibraryMethod())
                 {
-                    writer.Write("(...)* ");
+                    writer.Write("(...) ");
                 }
             }
 
@@ -770,6 +776,8 @@ namespace Il2Native.Logic.Gencode
 
                 // last part
                 writer.Write("load ");
+                typeToLoad.WriteTypePrefix(writer, structAsRef);
+                writer.Write(", ");
                 typeToLoad.WriteTypePrefix(writer, structAsRef);
                 if (appendReference)
                 {

--- a/Il2Native.Logic/Gencode/ObjectInfrastructure.cs
+++ b/Il2Native.Logic/Gencode/ObjectInfrastructure.cs
@@ -35,7 +35,7 @@ namespace Il2Native.Logic.Gencode
             var virtualTable = declaringType.GetVirtualTable(llvmWriter);
 
             return string.Format(
-                "getelementptr inbounds ([{0} x i8*]* {1}, i32 0, i32 {2})", 
+                "getelementptr inbounds ([{0} x i8*], [{0} x i8*]* {1}, i32 0, i32 {2})", 
                 virtualTable.GetVirtualTableSize(), 
                 declaringType.GetVirtualTableName(), 
                 FunctionsOffsetInVirtualTable);
@@ -53,7 +53,7 @@ namespace Il2Native.Logic.Gencode
         {
             var virtualInterfaceTable = declaringType.GetVirtualInterfaceTable(@interface);
             return string.Format(
-                "getelementptr inbounds ([{0} x i8*]* {1}, i32 0, i32 {2})", 
+                "getelementptr inbounds ([{0} x i8*], [{0} x i8*]* {1}, i32 0, i32 {2})", 
                 virtualInterfaceTable.GetVirtualTableSize(), 
                 declaringType.GetVirtualInterfaceTableName(@interface), 
                 FunctionsOffsetInVirtualTable);

--- a/Il2Native.Logic/Gencode/Rtti/RttiClassWithBaseAndInterfaces.cs
+++ b/Il2Native.Logic/Gencode/Rtti/RttiClassWithBaseAndInterfaces.cs
@@ -54,8 +54,8 @@ namespace Il2Native.Logic.Gencode
 
             writer.WriteLine("{");
             writer.Indent++;
-            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8** @_ZTVN10__cxxabiv121__vmi_class_type_infoE, i32 2) to i8*),");
-            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8]* @\"{0}\", i32 0, i32 0),", type.GetRttiStringName(), type.StringLength());
+            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8*, i8** @_ZTVN10__cxxabiv121__vmi_class_type_infoE, i32 2) to i8*),");
+            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8], [{1} x i8]* @\"{0}\", i32 0, i32 0),", type.GetRttiStringName(), type.StringLength());
             writer.WriteLine("i32 0,");
             writer.WriteLine("i32 {0}", @interfaces.Count() + (type.BaseType != null ? 1 : 0));
 

--- a/Il2Native.Logic/Gencode/Rtti/RttiClassWithBaseAndNoInterfaces.cs
+++ b/Il2Native.Logic/Gencode/Rtti/RttiClassWithBaseAndNoInterfaces.cs
@@ -39,8 +39,8 @@ namespace Il2Native.Logic.Gencode
 
             writer.WriteLine("{");
             writer.Indent++;
-            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8** @_ZTVN10__cxxabiv120__si_class_type_infoE, i32 2) to i8*),");
-            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8]* @\"{0}\", i32 0, i32 0),", type.GetRttiStringName(), type.StringLength());
+            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8*, i8** @_ZTVN10__cxxabiv120__si_class_type_infoE, i32 2) to i8*),");
+            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8], [{1} x i8]* @\"{0}\", i32 0, i32 0),", type.GetRttiStringName(), type.StringLength());
             writer.Write("i8* bitcast (");
             type.BaseType.WriteRttiClassInfoDeclaration(writer);
             writer.WriteLine("* @\"{0}\" to i8*)", type.BaseType.GetRttiInfoName());

--- a/Il2Native.Logic/Gencode/Rtti/RttiClassWithNoBaseAndNoInterfaces.cs
+++ b/Il2Native.Logic/Gencode/Rtti/RttiClassWithNoBaseAndNoInterfaces.cs
@@ -39,8 +39,8 @@ namespace Il2Native.Logic.Gencode
 
             writer.WriteLine("{");
             writer.Indent++;
-            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8** @_ZTVN10__cxxabiv117__class_type_infoE, i32 2) to i8*),");
-            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8]* @\"{0}\", i32 0, i32 0)", type.GetRttiStringName(), type.StringLength());
+            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8*, i8** @_ZTVN10__cxxabiv117__class_type_infoE, i32 2) to i8*),");
+            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8], [{1} x i8]* @\"{0}\", i32 0, i32 0)", type.GetRttiStringName(), type.StringLength());
             writer.Indent--;
             writer.WriteLine("}");
         }

--- a/Il2Native.Logic/Gencode/Rtti/RttiClassWithNoBaseAndSingleInterface.cs
+++ b/Il2Native.Logic/Gencode/Rtti/RttiClassWithNoBaseAndSingleInterface.cs
@@ -40,8 +40,8 @@ namespace Il2Native.Logic.Gencode
 
             writer.WriteLine("{");
             writer.Indent++;
-            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8** @_ZTVN10__cxxabiv120__si_class_type_infoE, i32 2) to i8*),");
-            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8]* @\"{0}\", i32 0, i32 0),", type.GetRttiStringName(), type.StringLength());
+            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8*, i8** @_ZTVN10__cxxabiv120__si_class_type_infoE, i32 2) to i8*),");
+            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8], [{1} x i8]* @\"{0}\", i32 0, i32 0),", type.GetRttiStringName(), type.StringLength());
             writer.Write("i8* bitcast (");
 
             var singleInheritanceType = type.GetInterfaces().First();

--- a/Il2Native.Logic/Gencode/Rtti/RttiPointerGen.cs
+++ b/Il2Native.Logic/Gencode/Rtti/RttiPointerGen.cs
@@ -97,8 +97,8 @@ namespace Il2Native.Logic.Gencode
         {
             writer.WriteLine("{");
             writer.Indent++;
-            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8** @_ZTVN10__cxxabiv119__pointer_type_infoE, i32 2) to i8*),");
-            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8]* @\"{0}\", i32 0, i32 0),", type.GetRttiPointerStringName(), type.StringLength(1));
+            writer.WriteLine("i8* bitcast (i8** getelementptr inbounds (i8*, i8** @_ZTVN10__cxxabiv119__pointer_type_infoE, i32 2) to i8*),");
+            writer.WriteLine("i8* getelementptr inbounds ([{1} x i8], [{1} x i8]* @\"{0}\", i32 0, i32 0),", type.GetRttiPointerStringName(), type.StringLength(1));
             writer.WriteLine("i32 0,");
             writer.Write("i8* bitcast (");
             type.WriteRttiClassInfoDeclaration(writer);

--- a/Il2Native.Logic/Gencode/TypeGen.cs
+++ b/Il2Native.Logic/Gencode/TypeGen.cs
@@ -501,6 +501,59 @@ namespace Il2Native.Logic.Gencode
         /// </param>
         /// <param name="writer">
         /// </param>
+        /// <param name="asReference">
+        /// </param>
+        public static void WriteTypeModifiers2(this IType type, IndentedTextWriter writer, bool asReference)
+        {
+            var refChar = '*';
+            var effectiveType = type;
+
+            if (type.IsArray)
+            {
+                //writer.Write(refChar);
+
+                if (type.IsByRef)
+                {
+                    writer.Write(refChar);
+                }
+
+                return;
+            }
+
+            var level = 0;
+            do
+            {
+                var isReference = !effectiveType.IsValueType;
+                //if ((isReference || (!isReference && asReference && level == 0) || effectiveType.IsPointer) && !effectiveType.IsGenericParameter
+                //    && !effectiveType.IsArray && !effectiveType.IsByRef)
+                //{
+                //    writer.Write(refChar);
+                //}
+
+                if (effectiveType.IsByRef || effectiveType.IsArray)
+                {
+                    writer.Write(refChar);
+                }
+
+                if (effectiveType.HasElementType && !effectiveType.IsArray)
+                {
+                    effectiveType = effectiveType.GetElementType();
+                    level++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+            while (effectiveType != null);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="type">
+        /// </param>
+        /// <param name="writer">
+        /// </param>
         /// <param name="isPointer">
         /// </param>
         public static void WriteTypeName(this IType type, LlvmIndentedTextWriter writer, bool isPointer)
@@ -528,6 +581,20 @@ namespace Il2Native.Logic.Gencode
         {
             type.WriteTypeWithoutModifiers(writer);
             type.WriteTypeModifiers(writer, asReference);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="type">
+        /// </param>
+        /// <param name="writer">
+        /// </param>
+        /// <param name="asReference">
+        /// </param>
+        public static void WriteTypePrefix2(this IType type, LlvmIndentedTextWriter writer, bool asReference = false)
+        {
+            type.WriteTypeWithoutModifiers(writer);
+            type.WriteTypeModifiers2(writer, asReference);
         }
 
         /// <summary>


### PR DESCRIPTION
I tried using IL2BC to compile `helloworld` example on `README.md` but failed with errors on LLVM 12.
This PR is the change that was necessary for running the `helloworld`.
But since I don't understand the code deeply and the fix is ad-hoc, please feel free to close the PR and fix it in another way.
